### PR TITLE
add package.json repository, homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "twemoji-parser",
   "version": "12.1.0",
   "description": "Parser for identifying Twemoji in text",
+  "homepage": "https://github.com/twitter/twemoji-parser",
   "main": "dist/index.js",
   "files": [
     "dist"
@@ -38,5 +39,9 @@
     "flow-typed": "^2.4.0",
     "jest": "^22.4.3",
     "prettier": "^1.12.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/twitter/twemoji-parser.git"
   }
 }


### PR DESCRIPTION
This makes it easier to find the source via npm repositories.

# Problem

When viewing twemoji-parser via [npm](https://www.npmjs.com/package/twemoji-parser) or [yarn](https://yarnpkg.com/en/package/twemoji-parser), it's hard to find the package source.

# Solution

I've added package.json metadata to point to this git repository.

# Result

Npm and yarn will point to this git repository.
